### PR TITLE
Support for existing LLM architectures to be used with the diffusion objective

### DIFF
--- a/.mlops-config.yaml
+++ b/.mlops-config.yaml
@@ -1,0 +1,4 @@
+conda_env: "tzd"
+train_script: "train.py"
+install_editable: true
+package_name: "tzd"

--- a/configs/config_qwen2.5_0.5b.yaml
+++ b/configs/config_qwen2.5_0.5b.yaml
@@ -1,0 +1,23 @@
+# Complete training config for Qwen2.5-0.5B Diffusion Model
+
+defaults:
+  - model: qwen2.5_0.5b
+  - tokenizer: qwen2.5
+  - training: default
+  - data: shakespeare
+  - _self_
+
+seed: 42
+
+# Override training params for finetuning pretrained model
+training:
+  epochs: 10  # Fewer epochs for finetuning
+  save_dir: ${hydra:runtime.output_dir}/qwen2.5_0.5b_diffusion
+  val_generation_freq: 2  # Generate samples every 2 epochs
+
+# WandB logger
+logger:
+ _target_: lightning.pytorch.loggers.WandbLogger
+ entity: tiny-zero-diffusion
+ project: diffusion_lm
+ name: ${oc.select:experiment_suffix,null}

--- a/configs/config_qwen2.5_0.5b.yaml
+++ b/configs/config_qwen2.5_0.5b.yaml
@@ -14,6 +14,9 @@ hydra:
   run:
     dir: /data/user_data/ruh/mlops-spark-jobs/outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
 
+tokenizer:
+  pretrained_model_name_or_path: "Qwen/Qwen2.5-0.5B"
+
 data:
   block_size: ${model.block_size}
   batch_size: 64

--- a/configs/config_qwen2.5_0.5b.yaml
+++ b/configs/config_qwen2.5_0.5b.yaml
@@ -9,11 +9,22 @@ defaults:
 
 seed: 42
 
+data:
+  block_size: ${model.block_size}
+  batch_size: 64
+  num_workers: 1
+  tokenizer: ${tokenizer}
+
+model:
+  tokenizer: ${tokenizer}
+  lr: 0.0005
+
 # Override training params for finetuning pretrained model
 training:
-  epochs: 10  # Fewer epochs for finetuning
-  save_dir: ${hydra:runtime.output_dir}/qwen2.5_0.5b_diffusion
-  val_generation_freq: 2  # Generate samples every 2 epochs
+  save_dir: ${hydra:runtime.output_dir}/checkpoints
+  epochs: 200
+  gradient_accumulation_steps: 3
+  val_generation_freq: 5
 
 # WandB logger
 logger:

--- a/configs/config_qwen2.5_0.5b.yaml
+++ b/configs/config_qwen2.5_0.5b.yaml
@@ -9,6 +9,11 @@ defaults:
 
 seed: 42
 
+# Override Hydra output directory
+hydra:
+  run:
+    dir: /data/user_data/ruh/mlops-spark-jobs/outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
+
 data:
   block_size: ${model.block_size}
   batch_size: 64

--- a/configs/config_qwen2.5_1.5b.yaml
+++ b/configs/config_qwen2.5_1.5b.yaml
@@ -1,18 +1,10 @@
-# Complete training config for Qwen2.5-3B Diffusion Model
-#
-# Usage:
-#   # Train with random weights (architecture only):
-#   python train.py --config-name config_qwen2.5_0.5b
-#
-#   # Train with pretrained weights (download first):
-#   litgpt download Qwen/Qwen2.5-3B
-#   python train.py --config-name config_qwen2.5_0.5b model.checkpoint_dir=checkpoints/Qwen/Qwen2.5-3B
+# Complete training config for Qwen2.5-1.5B Diffusion Model
 
 defaults:
   - model: qwen2.5_1.5b
-  - data: shakespeare  # Change to your dataset
-  - training: default
   - tokenizer: qwen2.5
+  - training: default
+  - data: shakespeare
   - _self_
 
 seed: 42

--- a/configs/config_qwen2.5_1.5b.yaml
+++ b/configs/config_qwen2.5_1.5b.yaml
@@ -9,6 +9,11 @@ defaults:
 
 seed: 42
 
+# Override Hydra output directory
+hydra:
+  run:
+    dir: /data/user_data/ruh/mlops-spark-jobs/outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
+
 data:
   block_size: ${model.block_size}
   batch_size: 64
@@ -22,7 +27,7 @@ model:
 # Override training params for finetuning pretrained model
 training:
   epochs: 10  # Fewer epochs for finetuning
-  save_dir: ${hydra:runtime.output_dir}/qwen2.5_1.5b_diffusion
+  save_dir: ${hydra:runtime.output_dir}/checkpoints
   val_generation_freq: 2  # Generate samples every 2 epochs
 
 # WandB logger

--- a/configs/config_qwen2.5_1.5b.yaml
+++ b/configs/config_qwen2.5_1.5b.yaml
@@ -9,6 +9,16 @@ defaults:
 
 seed: 42
 
+data:
+  block_size: ${model.block_size}
+  batch_size: 64
+  num_workers: 1
+  tokenizer: ${tokenizer}
+
+model:
+  tokenizer: ${tokenizer}
+  lr: 0.0005
+
 # Override training params for finetuning pretrained model
 training:
   epochs: 10  # Fewer epochs for finetuning

--- a/configs/config_qwen2.5_1.5b.yaml
+++ b/configs/config_qwen2.5_1.5b.yaml
@@ -1,0 +1,31 @@
+# Complete training config for Qwen2.5-3B Diffusion Model
+#
+# Usage:
+#   # Train with random weights (architecture only):
+#   python train.py --config-name config_qwen2.5_0.5b
+#
+#   # Train with pretrained weights (download first):
+#   litgpt download Qwen/Qwen2.5-3B
+#   python train.py --config-name config_qwen2.5_0.5b model.checkpoint_dir=checkpoints/Qwen/Qwen2.5-3B
+
+defaults:
+  - model: qwen2.5_1.5b
+  - data: shakespeare  # Change to your dataset
+  - training: default
+  - tokenizer: qwen2.5
+  - _self_
+
+seed: 42
+
+# Override training params for finetuning pretrained model
+training:
+  epochs: 10  # Fewer epochs for finetuning
+  save_dir: ${hydra:runtime.output_dir}/qwen2.5_1.5b_diffusion
+  val_generation_freq: 2  # Generate samples every 2 epochs
+
+# WandB logger
+logger:
+ _target_: lightning.pytorch.loggers.WandbLogger
+ entity: tiny-zero-diffusion
+ project: diffusion_lm
+ name: ${oc.select:experiment_suffix,null}

--- a/configs/config_qwen2.5_1.5b.yaml
+++ b/configs/config_qwen2.5_1.5b.yaml
@@ -14,6 +14,9 @@ hydra:
   run:
     dir: /data/user_data/ruh/mlops-spark-jobs/outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
 
+tokenizer:
+  pretrained_model_name_or_path: "Qwen/Qwen2.5-1.5B"
+
 data:
   block_size: ${model.block_size}
   batch_size: 64

--- a/configs/model/qwen2.5_0.5b.yaml
+++ b/configs/model/qwen2.5_0.5b.yaml
@@ -15,7 +15,7 @@ model:
   block_size: 256
 
   # Download with: litgpt download Qwen/Qwen2.5-0.5B
-  checkpoint_dir: /home/ruh/mlops-spark-jobs/tinyzero_diffusion-1763529458090/checkpoints/Qwen/Qwen2.5-0.5B
+  checkpoint_dir: /data/user_data/ruh/mlops-spark-jobs/checkpoints/Qwen/Qwen2.5-0.5B
 
   # Generation parameters
   val_generation_freq: ${training.val_generation_freq}

--- a/configs/model/qwen2.5_0.5b.yaml
+++ b/configs/model/qwen2.5_0.5b.yaml
@@ -1,5 +1,5 @@
 # @package _global_
-# Qwen2.5-1.5B Pretrained Model Config
+# Qwen2.5-0.5B Pretrained Model Config
 #
 # Smaller model for faster training and testing.
 # Good for prototyping before scaling to 3B.
@@ -7,15 +7,15 @@
 model:
   _target_: tzd.models.diffusion_pretrained.from_pretrained
 
-  pretrained_model_name: "Qwen2.5-1.5B"
+  pretrained_model_name: "Qwen2.5-0.5B"
   tokenizer: ${tokenizer}
-  model_alias: qwen2.5_1.5b_diffusion
+  model_alias: qwen2.5_0.5b_diffusion
   lr: 1e-5
 
   block_size: 256
 
-  # Download with: litgpt download Qwen/Qwen2.5-1.5B
-  checkpoint_dir: /home/ruh/mlops-spark-jobs/tinyzero_diffusion-1763529458090/checkpoints/Qwen/Qwen2.5-1.5B
+  # Download with: litgpt download Qwen/Qwen2.5-0.5B
+  checkpoint_dir: /home/ruh/mlops-spark-jobs/tinyzero_diffusion-1763529458090/checkpoints/Qwen/Qwen2.5-0.5B
 
   # Generation parameters
   val_generation_freq: ${training.val_generation_freq}

--- a/configs/model/qwen2.5_1.5b.yaml
+++ b/configs/model/qwen2.5_1.5b.yaml
@@ -15,7 +15,7 @@ model:
   block_size: 256
 
   # Download with: litgpt download Qwen/Qwen2.5-1.5B
-  checkpoint_dir: /home/ruh/mlops-spark-jobs/tinyzero_diffusion-1763529458090/checkpoints/Qwen/Qwen2.5-1.5B
+  checkpoint_dir: /data/user_data/ruh/mlops-spark-jobs/checkpoints/Qwen/Qwen2.5-1.5B
 
   # Generation parameters
   val_generation_freq: ${training.val_generation_freq}

--- a/configs/model/qwen2.5_1.5b.yaml
+++ b/configs/model/qwen2.5_1.5b.yaml
@@ -13,7 +13,7 @@ model:
   lr: 1e-5
 
   # Download with: litgpt download Qwen/Qwen2.5-1.5B
-  checkpoint_dir: null
+  checkpoint_dir: /home/ruh/mlops-spark-jobs/tinyzero_diffusion-1763529458090/checkpoints/Qwen/Qwen2.5-1.5B
 
   # Generation parameters
   val_generation_freq: ${training.val_generation_freq}

--- a/configs/model/qwen2.5_1.5b.yaml
+++ b/configs/model/qwen2.5_1.5b.yaml
@@ -1,0 +1,23 @@
+# @package _global_
+# Qwen2.5-1.5B Pretrained Model Config
+#
+# Smaller model for faster training and testing.
+# Good for prototyping before scaling to 3B.
+
+model:
+  _target_: tzd.models.diffusion_pretrained.from_pretrained
+
+  pretrained_model_name: "Qwen2.5-1.5B"
+  tokenizer: ${tokenizer}
+  model_alias: qwen2.5_1.5b_diffusion
+  lr: 1e-5
+
+  # Download with: litgpt download Qwen/Qwen2.5-1.5B
+  checkpoint_dir: null
+
+  # Generation parameters
+  val_generation_freq: ${training.val_generation_freq}
+  val_temperatures: [1.0]
+  generation_block_size: 256
+  generation_num_steps: 128
+  sampling_repo: LLaDA

--- a/configs/model/qwen2.5_1.5b.yaml
+++ b/configs/model/qwen2.5_1.5b.yaml
@@ -12,6 +12,8 @@ model:
   model_alias: qwen2.5_1.5b_diffusion
   lr: 1e-5
 
+  block_size: 256
+  
   # Download with: litgpt download Qwen/Qwen2.5-1.5B
   checkpoint_dir: /home/ruh/mlops-spark-jobs/tinyzero_diffusion-1763529458090/checkpoints/Qwen/Qwen2.5-1.5B
 

--- a/configs/tokenizer/qwen2.5.yaml
+++ b/configs/tokenizer/qwen2.5.yaml
@@ -1,0 +1,9 @@
+# @package _global_
+# Qwen2.5 Tokenizer Config
+#
+# Works for all Qwen2.5 models (0.5B, 1.5B, 3B, 7B, etc.)
+
+tokenizer:
+  _target_: transformers.AutoTokenizer.from_pretrained
+  pretrained_model_name_or_path: "Qwen/Qwen2.5-3B"
+  trust_remote_code: false  # Qwen2.5 doesn't need remote code

--- a/configs/tokenizer/qwen2.5.yaml
+++ b/configs/tokenizer/qwen2.5.yaml
@@ -5,5 +5,5 @@
 
 tokenizer:
   _target_: transformers.AutoTokenizer.from_pretrained
-  pretrained_model_name_or_path: "Qwen/Qwen2.5-3B"
+  pretrained_model_name_or_path: ""
   trust_remote_code: false  # Qwen2.5 doesn't need remote code

--- a/src/tzd/data/datamodule.py
+++ b/src/tzd/data/datamodule.py
@@ -46,13 +46,10 @@ class TinyShakespeareDataset(Dataset):
             tokens = tokenizer.encode(self.text, add_special_tokens=False)
             print(f"[DEBUG] Encoded {len(tokens)} tokens.")
 
-            # 2. Determine Strategy based on Tokenizer
             bos_id = tokenizer.bos_token_id
             
             if bos_id is None:
-                # --- Qwen2.5 Strategy (No BOS) ---
-                # We need exactly 'block_size' tokens from the text.
-                print("[DEBUG] Model type: Qwen (No BOS). Using raw chunks.")
+                print("[DEBUG] Model type: (No BOS). Using raw chunks.")
                 chunk_size = block_size
                 
                 self.data = [
@@ -60,8 +57,6 @@ class TinyShakespeareDataset(Dataset):
                     for i in range(0, len(tokens) - chunk_size, chunk_size)
                 ]
             else:
-                # --- Llama Strategy (With BOS) ---
-                # We take 'block_size - 1' tokens and prepend BOS.
                 print(f"[DEBUG] Model type: Standard (BOS found: {bos_id}). Prepending BOS.")
                 chunk_size = block_size - 1
                 

--- a/src/tzd/models/diffusion.py
+++ b/src/tzd/models/diffusion.py
@@ -44,7 +44,7 @@ class DiffusionModel(BaseModel):
         self.block_size = block_size
         self.vocab_size = tokenizer.vocab_size
         self.model_type = model_type
-        self.mask_token_id = tokenizer.pad_token_id if tokenizer.pad_token_id is not None else tokenizer.eos_token_id
+        self.mask_token_id = tokenizer.mask_token_id
 
         # inference parameters
         self.val_generation_freq   = kwargs.get("val_generation_freq", 5)

--- a/src/tzd/models/diffusion.py
+++ b/src/tzd/models/diffusion.py
@@ -33,7 +33,7 @@ class DiffusionModel(BaseModel):
         block_size: int,
         tokenizer: callable,
         bias: bool = True,
-        model_type: str = "smdm",  # 'smdm' or 'litgpt'
+        model_type: str = "litgpt",  # 'smdm' or 'litgpt'
         **kwargs
     ):
         """
@@ -51,7 +51,7 @@ class DiffusionModel(BaseModel):
         self.generation_block_size = kwargs.get("generation_block_size", block_size)
         self.val_temperatures       = kwargs.get("val_temperatures", [1.0])
         self.generation_num_steps  = kwargs.get("generation_num_steps", block_size // 2)
-        self.sampling_repo         = kwargs.get("sampling_repo", "SMDM")  # Default to SMDM
+        self.sampling_repo         = kwargs.get("sampling_repo", "LLaDA")  # Default to LLaDA (SMDM requires rotary_emb)
 
         self.unk_token_id = tokenizer.unk_token_id  # unknown token id that avoid loss computation
 
@@ -183,14 +183,14 @@ class DiffusionModel(BaseModel):
                 import traceback
                 traceback.print_exc()
 
-    def sample(self, batch_size=1, seq_len=None, num_steps=None, temperature=1.0, repo="SMDM"):
+    def sample(self, batch_size=1, seq_len=None, num_steps=None, temperature=1.0, repo="LLaDA"):
         """Call inference functions borrowed from SMDM's & LLaDA's inference.py
 
         :param batch_size: Number of sequences to generate
         :param seq_len: Length of sequences to generate (defaults to model's block_size)
         :param num_steps: Number of denoising steps (defaults to seq_len // 2)
         :param temperature: Sampling temperature (0.0 for greedy)
-        :param repo: Sampling method to use ('SMDM' or 'LLaDA')
+        :param repo: Sampling method to use ('LLaDA' or 'SMDM'). Defaults to 'LLaDA' (SMDM requires rotary_emb)
         :return tokens: Generated sequences of shape (batch_size, seq_len)
         """
         device = next(self.parameters()).device

--- a/src/tzd/models/diffusion.py
+++ b/src/tzd/models/diffusion.py
@@ -79,20 +79,27 @@ class DiffusionModel(BaseModel):
 
         elif model_type == "litgpt":
             # New LitGPT path with non-causal attention
-            config = LitGPTConfig(
-                vocab_size=self.vocab_size,
-                padded_vocab_size=self.vocab_size,
-                n_layer=n_layer,
-                n_head=n_head,
-                n_embd=n_embd,
-                block_size=block_size,
-                bias=bias,
-                causal=False,  # Non-causal attention for diffusion
-                norm_class_name=kwargs.get("norm_class_name", "LayerNorm"),
-                mlp_class_name=kwargs.get("mlp_class_name", "GptNeoxMLP"),
-                intermediate_size=kwargs.get("intermediate_size", 4 * n_embd),
-                rotary_percentage=kwargs.get("rotary_percentage", 1.0),
-            )
+            # If a pre-built litgpt_config is provided (from pretrained), use it
+            if "litgpt_config" in kwargs:
+                config = kwargs["litgpt_config"]
+                # Ensure causal=False for diffusion
+                config.causal = False
+            else:
+                # Build config from scratch
+                config = LitGPTConfig(
+                    vocab_size=self.vocab_size,
+                    padded_vocab_size=self.vocab_size,
+                    n_layer=n_layer,
+                    n_head=n_head,
+                    n_embd=n_embd,
+                    block_size=block_size,
+                    bias=bias,
+                    causal=False,  # Non-causal attention for diffusion
+                    norm_class_name=kwargs.get("norm_class_name", "LayerNorm"),
+                    mlp_class_name=kwargs.get("mlp_class_name", "GptNeoxMLP"),
+                    intermediate_size=kwargs.get("intermediate_size", 4 * n_embd),
+                    rotary_percentage=kwargs.get("rotary_percentage", 1.0),
+                )
             self.model = GPT(config)
         else:
             raise ValueError(f"Unknown model_type: {model_type}. Supported: 'smdm', 'litgpt'")

--- a/src/tzd/models/diffusion_pretrained.py
+++ b/src/tzd/models/diffusion_pretrained.py
@@ -1,0 +1,142 @@
+"""Helper functions for loading pretrained checkpoints into DiffusionModel.
+
+This module provides utilities to:
+1. Load pretrained model configs from LitGPT's registry
+2. Convert HuggingFace weights to LitGPT format
+3. Initialize DiffusionModel with pretrained weights and causal=False
+"""
+
+import torch
+from pathlib import Path
+from typing import Optional
+from litgpt.config import Config as LitGPTConfig
+from tzd.models.diffusion import DiffusionModel
+
+
+def from_pretrained(
+    pretrained_model_name: str,
+    tokenizer: callable,
+    model_alias: str = "diffusion_from_pretrained",
+    lr: float = 1e-5,
+    checkpoint_dir: Optional[Path] = None,
+    **kwargs
+) -> DiffusionModel:
+    """
+    Load a pretrained model and convert to a diffusion model.
+
+    This function uses LitGPT's config registry to automatically populate
+    all architecture parameters from well-known model names like "Qwen2.5-3B".
+
+    Args:
+        pretrained_model_name: Model name recognized by LitGPT
+                              (e.g., "Qwen2.5-3B", "Llama-3-8B", "phi-2")
+                              Run `litgpt download list` to see all supported models
+        tokenizer: Tokenizer instance
+        model_alias: Name for this model instance
+        lr: Learning rate
+        checkpoint_dir: Optional path to pre-downloaded LitGPT checkpoint
+                       If None, will load from HuggingFace directly
+        **kwargs: Override any config parameters (e.g., block_size=256)
+
+    Returns:
+        DiffusionModel with pretrained architecture (and weights if checkpoint_dir provided)
+
+    Example:
+        >>> from transformers import AutoTokenizer
+        >>> tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen2.5-3B")
+        >>>
+        >>> # Option 1: Load config only (random weights)
+        >>> model = from_pretrained(
+        ...     "Qwen2.5-3B",
+        ...     tokenizer=tokenizer,
+        ...     block_size=256,  # Override for shorter sequences
+        ... )
+        >>>
+        >>> # Option 2: Load config + weights from downloaded checkpoint
+        >>> model = from_pretrained(
+        ...     "Qwen2.5-3B",
+        ...     tokenizer=tokenizer,
+        ...     checkpoint_dir=Path("checkpoints/Qwen/Qwen2.5-3B"),
+        ... )
+    """
+    # Load LitGPT config by name
+    try:
+        litgpt_config = LitGPTConfig.from_name(pretrained_model_name)
+        print(f"✓ Loaded LitGPT config for: {pretrained_model_name}")
+    except (ValueError, StopIteration) as e:
+        raise ValueError(
+            f"Could not find LitGPT config for '{pretrained_model_name}'. "
+            f"Available configs can be listed with: litgpt download list"
+        ) from e
+
+    # Apply user overrides
+    for key, value in kwargs.items():
+        if hasattr(litgpt_config, key):
+            setattr(litgpt_config, key, value)
+
+    # CRITICAL: Set causal=False for diffusion models
+    litgpt_config.causal = False
+
+    print(f"\n{'='*60}")
+    print(f"Creating DiffusionModel from {pretrained_model_name}")
+    print(f"{'='*60}")
+    print(f"Architecture:")
+    print(f"  Layers: {litgpt_config.n_layer}")
+    print(f"  Attention heads: {litgpt_config.n_head}")
+    print(f"  Embedding dim: {litgpt_config.n_embd}")
+    print(f"  Vocab size: {litgpt_config.vocab_size}")
+    print(f"  Block size: {litgpt_config.block_size}")
+    print(f"  Normalization: {litgpt_config.norm_class_name}")
+    print(f"  MLP: {litgpt_config.mlp_class_name}")
+    print(f"  Intermediate size: {litgpt_config.intermediate_size}")
+    print(f"Diffusion settings:")
+    print(f"  Causal attention: {litgpt_config.causal} (non-causal for diffusion)")
+    print(f"{'='*60}\n")
+
+    # Create DiffusionModel with LitGPT architecture
+    # We pass the full litgpt_config in kwargs, which contains all architecture details
+    # The individual parameters are needed to satisfy DiffusionModel's __init__ signature
+    model = DiffusionModel(
+        model_alias=model_alias,
+        lr=lr,
+        n_layer=litgpt_config.n_layer,
+        n_head=litgpt_config.n_head,
+        n_embd=litgpt_config.n_embd,
+        block_size=litgpt_config.block_size,
+        tokenizer=tokenizer,
+        bias=litgpt_config.bias,
+        model_type="litgpt",
+        litgpt_config=litgpt_config,  # This is what actually gets used for the GPT model
+    )
+
+    # Load pretrained weights if checkpoint directory provided
+    if checkpoint_dir is not None:
+        checkpoint_path = Path(checkpoint_dir) / "lit_model.pth"
+        if not checkpoint_path.exists():
+            raise FileNotFoundError(
+                f"Checkpoint not found: {checkpoint_path}\n"
+                f"Download it first using:\n"
+                f"  litgpt download {pretrained_model_name}"
+            )
+
+        print(f"Loading pretrained weights from: {checkpoint_path}")
+        state_dict = torch.load(str(checkpoint_path), map_location="cpu")
+
+        # Handle both raw state dict and checkpoint dict with 'model' key
+        if isinstance(state_dict, dict) and "model" in state_dict:
+            state_dict = state_dict["model"]
+
+        missing, unexpected = model.model.load_state_dict(state_dict, strict=False)
+
+        if missing:
+            print(f"⚠ Missing keys: {len(missing)} (first 3: {', '.join(missing[:3])})")
+        if unexpected:
+            print(f"⚠ Unexpected keys: {len(unexpected)} (first 3: {', '.join(unexpected[:3])})")
+
+        loaded = len(model.model.state_dict()) - len(missing)
+        print(f"✓ Loaded {loaded}/{len(model.model.state_dict())} weight tensors\n")
+    else:
+        print(f"⚠ No checkpoint_dir provided - initialized with random weights")
+        print(f"   To download: litgpt download {pretrained_model_name}\n")
+
+    return model

--- a/src/tzd/models/diffusion_pretrained.py
+++ b/src/tzd/models/diffusion_pretrained.py
@@ -81,14 +81,16 @@ def from_pretrained(
     tokenizer.pad_token = "<|endoftext|>"
     tokenizer.pad_token_id = tokenizer.convert_tokens_to_ids("<|endoftext|>") # Should be 151643
 
-    # 3. Add the Noise Token (MASK)
-    # We add a new special token to avoid conflict with PAD/EOS
-    if "<|MASK|>" not in tokenizer.get_vocab():
-        tokenizer.add_special_tokens({"additional_special_tokens": ["<|MASK|>"]})
+    tokenizer.mask_token ="<|fim_middle|>"
+    tokenizer.mask_token_id = tokenizer.convert_tokens_to_ids("<|fim_middle|>")    
+    # # 3. Add the Noise Token (MASK)
+    # # We add a new special token to avoid conflict with PAD/EOS
+    # if "<|MASK|>" not in tokenizer.get_vocab():
+    #     tokenizer.add_special_tokens({"additional_special_tokens": ["<|MASK|>"]})
         
-    # Force the attribute so we can find it easily later
-    tokenizer.mask_token = "<|MASK|>"
-    tokenizer.mask_token_id = tokenizer.convert_tokens_to_ids("<|MASK|>")
+    # # Force the attribute so we can find it easily later
+    # tokenizer.mask_token = "<|MASK|>"
+    # tokenizer.mask_token_id = tokenizer.convert_tokens_to_ids("<|MASK|>")
 
     print(f"[CONFIG] BOS ID: {tokenizer.bos_token_id} (<|im_start|>)")
     print(f"[CONFIG] PAD ID: {tokenizer.pad_token_id} (<|endoftext|>)")

--- a/src/tzd/models/diffusion_pretrained.py
+++ b/src/tzd/models/diffusion_pretrained.py
@@ -81,8 +81,8 @@ def from_pretrained(
     tokenizer.pad_token = "<|endoftext|>"
     tokenizer.pad_token_id = tokenizer.convert_tokens_to_ids("<|endoftext|>") # Should be 151643
 
-    tokenizer.mask_token ="<|fim_middle|>"
-    tokenizer.mask_token_id = tokenizer.convert_tokens_to_ids("<|fim_middle|>")    
+    tokenizer.mask_token = "<|endoftext|>"
+    tokenizer.mask_token_id = tokenizer.convert_tokens_to_ids("<|endoftext|>")    
     # # 3. Add the Noise Token (MASK)
     # # We add a new special token to avoid conflict with PAD/EOS
     # if "<|MASK|>" not in tokenizer.get_vocab():
@@ -94,7 +94,7 @@ def from_pretrained(
 
     print(f"[CONFIG] BOS ID: {tokenizer.bos_token_id} (<|im_start|>)")
     print(f"[CONFIG] PAD ID: {tokenizer.pad_token_id} (<|endoftext|>)")
-    print(f"[CONFIG] MASK ID: {tokenizer.mask_token_id} (<|MASK|>)")
+    print(f"[CONFIG] MASK ID: {tokenizer.mask_token_id} {tokenizer.mask_token}")
 
     # Load LitGPT config by name
     try:

--- a/src/tzd/utils/generation.py
+++ b/src/tzd/utils/generation.py
@@ -25,7 +25,7 @@ def generate_samples(
 
     with torch.no_grad():
         # Use the model's configured sampling method (LLaDA or SMDM)
-        repo = getattr(model, 'sampling_repo', 'SMDM')
+        repo = getattr(model, 'sampling_repo', 'LLaDA')  # Default to LLaDA (SMDM requires rotary_emb)
         samples = model.sample(
             batch_size=batch_size,
             seq_len=seq_len,


### PR DESCRIPTION
Given a standard LLM config, now we can repurpose it as a diffusion language model.

Tricky things to consider:
- handling LLMs that do not have a bos token and mask token

Weird behaviours fixed:
- defaulting to LLADA for generation (not smdm backend)
- deceptively defaulting to llama tokenizer method; now it throws an error if the tokenizer was not specified properly 